### PR TITLE
bpftrace should not fetch arbitrary version of bcc during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if (OFFLINE_BUILDS)
   include(ExternalProject)
   ExternalProject_Add(bcc
     GIT_REPOSITORY https://github.com/iovisor/bcc
+    GIT_TAG v0.8.0
     STEP_TARGETS build update
     EXCLUDE_FROM_ALL 1
     UPDATE_DISCONNECTED 1
@@ -35,6 +36,7 @@ else()
   include(ExternalProject)
   ExternalProject_Add(bcc
     GIT_REPOSITORY https://github.com/iovisor/bcc
+    GIT_TAG v0.8.0
     STEP_TARGETS build update
     EXCLUDE_FROM_ALL 1
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --target bcc-static


### PR DESCRIPTION
This is a stop-gap solution to unblock linux-pkg.
This forces bpftrace to fetch a specific version of bcc (tag v0.8.0) instead of getting the latest one.

## TESTING
linux-pkg build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/19/console
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/392/console