### PR TITLE
update build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,22 +22,20 @@ Build-Depends: bison,
                cmake,
                flex,
                g++,
+               git,
                libelf-dev,
                zlib1g-dev,
                libfl-dev,
-               clang-5.0,
-               libclang-5.0-dev,
-               libclang-common-5.0-dev,
-               libclang1-5.0,
-               libllvm5.0,
-               llvm-5.0,
-               llvm-5.0-dev,
-               llvm-5.0-runtime
+               systemtap-sdt-dev,
+               llvm-7-dev,
+               llvm-7-runtime,
+               libclang-7-dev,
+               clang-7
 Standards-Version: 4.1.2
 
 Package: bpftrace
 Architecture: any
-Depends: ${shlibs:Depends}, libclang1-5.0, libllvm5.0
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Linux live kernel tracing tool.
   BPFtrace is a high-level tracing language for Linux enhanced Berkeley Packet
   Filter (eBPF) available in recent kernels.


### PR DESCRIPTION
This depends on https://github.com/delphix/linux-pkg/pull/54

bpftrace is now available as a package on Ubuntu 19.04, and it has the dependencies below.

Switching to llvm7/clang7 fixes https://github.com/iovisor/bpftrace/issues/76, so we should be able to remove the custom llvm5/clang5 ppa we are using in linux-pkg to build bpftrace.

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2184/ (pass)