### PR TITLE
Always include CC_USING_FENTRY

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -601,6 +601,7 @@ int main(int argc, char *argv[])
   }
   extra_flags.push_back("-include");
   extra_flags.push_back(CLANG_WORKAROUNDS_H);
+  extra_flags.push_back("-DCC_USING_FENTRY");
 
   for (auto dir : include_dirs)
   {


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3543/

We will need to make sure that we modify all our bpftrace scripts to not define CC_USING_FENTRY or we well get double-define errors. I would welcome anyone who knew off the top of their heads where to find all of these; if not, I'll do a thorough search through our repositories before we merge this.