### PR TITLE
DLPX-72381 [Backport of DLPX-70057 to 6.0.6.0] nfs_delete in delphix-stat service is broken

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -599,6 +599,7 @@ int main(int argc, char *argv[])
   }
   extra_flags.push_back("-include");
   extra_flags.push_back(CLANG_WORKAROUNDS_H);
+  extra_flags.push_back("-DCC_USING_FENTRY");
 
   for (auto dir : include_dirs)
   {


### PR DESCRIPTION
This is a clean backport of a patch to master that works around a compiler issue with bpftrace

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4197/