### PR TITLE
DLPX-85544 - update build tool dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,9 @@ Build-Depends: bison,
                asciidoctor,
                libdw1,
                libdw-dev,
-               pkg-config
+               pkg-config,
+	       dwarves,
+	       xxd
 Standards-Version: 4.1.2
 
 Package: bpftrace


### PR DESCRIPTION
### Description
A recent upstream commit added additional build tool dependencies that were not reflected in our debian/rules.

This adds the missing tools so that the merge job can succeed.  The build needed `xxd` and  `pahole`, which is in the `dwarves` package for Ubuntu 20.04. The other tools were already present.


### Testing
ab-pre-push (test building with new dependencies):
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5114/