### PR TITLE
DLPX-90396 bpftrace broken with strings

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,7 +22,7 @@ Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
     { ConfigKeyInt::max_type_res_iterations, { .value = (uint64_t)0 } },
     { ConfigKeyInt::perf_rb_pages, { .value = (uint64_t)64 } },
     { ConfigKeyStackMode::default_, { .value = StackMode::bpftrace } },
-    { ConfigKeyString::str_trunc_trailer, { .value = ".." } },
+    { ConfigKeyString::str_trunc_trailer, { .value = std::string("..") } },
     // by default, cache user symbols per program if ASLR is disabled on system
     // or `-c` option is given
     { ConfigKeyUserSymbolCacheType::default_,


### PR DESCRIPTION
Right now, if you try to run a simple bpftrace script involving strings, you get an error:

```
$ sudo bpftrace -e 'BEGIN {printf("%s\n", "hello");}'
Attaching 1 probe...
terminate called after throwing an instance of 'std::runtime_error'
  what():  Type mismatch for config key
Aborted
```
After much debugging, it turns out the problem here is that the str_trunc_trailer's default value is not getting set correctly for us (though presumably it is upstream). This change patches the issue so that bpftrace works again. We may also want to investigate why upstream is not running into this problem. My guess is a version difference in our compiler or toolchain.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8127/