### PR TITLE
DLPX-91603 Revert "DLPX-91538 Upstream merge conflict in bpftrace"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 
 add_compile_options("-Wall")
 add_compile_options("-Wextra")
+add_compile_options("-Wundef")
 add_compile_options("-Wpointer-arith")
 add_compile_options("-Wcast-align")
 add_compile_options("-Wwrite-strings")


### PR DESCRIPTION
Reverts delphix/bpftrace#30

[**Note:** The github generated [PR 32](https://github.com/delphix/bpftrace/pull/32) won't let me update it (with git review) and there is a failing jira check. So, this is take two.]

Looks like my merge PR 30 missed some changes. I am reverting that change so that we can redo the merge conflict fix.

This change essentially takes us back to the state prior to PR 30.

```
mjoseph@manojjosephsmbp bpftrace % git log -2
commit 00815a21142bbbd51fb96364a9d0f739603013f7 
Author: Manoj Joseph <manoj.joseph@delphix.com>
Date:   Tue Jul 9 12:32:20 2024 -0700

    DLPX-91603 Revert "DLPX-91538 Upstream merge conflict in bpftrace"
    
    PR URL: https://www.github.com/delphix/bpftrace/pull/34

commit b615f00ea95f972763ed27b6938a76eb0f221fe5 (origin/develop, origin/HEAD, revert2)
Merge: fb90fc7d 52c9c328
Author: Manoj Joseph <manoj.joseph@delphix.com>
Date:   Sun Jun 30 22:34:04 2024 -0700

    Merge pull request #30 from delphix/dlpx/pr/manoj-joseph/b2d64e98-0d65-474d-8532-84c91330818a
    
    DLPX-91538 Upstream merge conflict in bpftrace
mjoseph@manojjosephsmbp bpftrace % git diff fb90fc7d2194f5f81fb0a473d86bc4058732552d
mjoseph@manojjosephsmbp bpftrace %  
```